### PR TITLE
fix: prevent Any type from shadowing type errors in match arms

### DIFF
--- a/src/fun/check/type_check.rs
+++ b/src/fun/check/type_check.rs
@@ -593,6 +593,15 @@ fn infer_match_cases(
       let (s_rest, t_rest) = infer_match_cases(env.subst(&s), book, types, adt, rest, adt_s, var_gen)?;
       let (t_final, s_final) = unify_term(&t1.subst(&s), &t_rest, bod)?;
 
+      // If the final type is `Any` but t1 (from non-unreachable arm) has type variables,
+      // we need to use t1's type to preserve those constraints
+      if let Type::Any = &t_final {
+        let t1_vars = t1.free_type_vars();
+        if !t1_vars.is_empty() {
+          return Ok((s_final.compose(s_rest).compose(s.clone()), t1.subst(&s)));
+        }
+      }
+
       Ok((s_final.compose(s_rest).compose(s), t_final))
     } else {
       Ok((Subst::default(), var_gen.fresh()))


### PR DESCRIPTION
## Summary

When `unreachable()` is used in a match arm, the type checker infers `Any` as the return type. Since `Any` can unify with anything in the unification function, it absorbs type constraints from other arms, allowing invalid types to pass without error.

## Fix

Modified `infer_match_cases` in `type_check.rs` to preserve the type constraints from non-`Any` arms. When the final unified type is `Any` but a previous arm has free type variables, we use the previous arm's type to preserve those constraints.

## Test

The fix was verified against the test case from issue #742:

```bend
type Maybe(T):
  Some{val: T}
  None

def Maybe/bug(maybe: Maybe(A)) -> Maybe(A):
  match maybe:
    case Maybe/Some:
      return Maybe/Some(Maybe/Some(maybe.val))
    case Maybe/None:
      return unreachable()
```

Before fix: No type error (incorrect)
After fix: Type error as expected

All existing tests pass (20 passed, 2 ignored).