### PR TITLE
docs: relative fs path links

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -816,7 +816,7 @@ reach 1000+ MIPS.
 ## To be continued...
 
 This guide isn't extensive, and there's a lot uncovered. For example, Bend also
-has an entire Haskell-like functional syntax that is compatible with old HVM1, you can find it documented [here](https://github.com/HigherOrderCO/Bend/blob/main/docs/syntax.md#fun-syntax). You can also check [this](https://gist.github.com/VictorTaelin/9cbb43e2b1f39006bae01238f99ff224) out, it's an implementation of the Bitonic Sort with Haskell-like equations. 
+has an entire Haskell-like functional syntax that is compatible with old HVM1, you can find it documented [here](docs/syntax.md#fun-syntax). You can also check [this](https://gist.github.com/VictorTaelin/9cbb43e2b1f39006bae01238f99ff224) out, it's an implementation of the Bitonic Sort with Haskell-like equations.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ## Introduction
 
-Bend offers the feel and features of expressive languages like Python and Haskell. This includes fast object allocations, full support for higher-order functions with closures, unrestricted recursion, and even continuations.                             
-Bend scales like CUDA, it runs on massively parallel hardware like GPUs, with nearly linear acceleration based on core count, and without explicit parallelism annotations: no thread creation, locks, mutexes, or atomics.                     
+Bend offers the feel and features of expressive languages like Python and Haskell. This includes fast object allocations, full support for higher-order functions with closures, unrestricted recursion, and even continuations.
+Bend scales like CUDA, it runs on massively parallel hardware like GPUs, with nearly linear acceleration based on core count, and without explicit parallelism annotations: no thread creation, locks, mutexes, or atomics.
 Bend is powered by the [HVM2](https://github.com/higherorderco/hvm) runtime.
 
 
@@ -108,7 +108,7 @@ def Sum(start, target):
   else:
     # If start is not equal to target, recursively call Sum with
     # start incremented by 1, and add the result to start.
-    return start + Sum(start + 1, target)  
+    return start + Sum(start + 1, target)
 
 def main():
   # This translates to (1 + (2 + (3 + (...... + (999999 + 1000000)))))
@@ -163,7 +163,7 @@ def main():
   return Sum(1, 1_000_000)
 ```
 
-In this example, the (3 + 4) sum does not depend on the (1 + 2), meaning that it can run in parallel because both computations can happen at the same time. 
+In this example, the (3 + 4) sum does not depend on the (1 + 2), meaning that it can run in parallel because both computations can happen at the same time.
 
 ##### Running the file
 You can run it using Rust interpreter (Sequential)
@@ -195,7 +195,7 @@ The code snippet below implements a [bitonic sorter](https://en.wikipedia.org/wi
 
  <details>
   <summary><b>Click here for the Bitonic Sorter code</b></summary>
-   
+
 
 ```py
 # Sorting Network = just rotate trees!
@@ -274,13 +274,13 @@ def main:
 ```
 
 </details>
-  
-if you are interested in some other algorithms, you can check our [examples folder](https://github.com/HigherOrderCO/Bend/tree/main/examples)
+
+if you are interested in some other algorithms, you can check our [examples folder](examples)
 
 
 ### Additional Resources
  - To understand the technology behind Bend, check out the HVM2 [paper](https://paper.higherorderco.com/).
  - We are working on an official documentation, meanwhile for a more in depth
-     explanation check [GUIDE.md](https://github.com/HigherOrderCO/Bend/blob/main/GUIDE.md)
- - Read about our features at [FEATURES.md](https://github.com/HigherOrderCO/Bend/blob/main/FEATURES.md)
+     explanation check [GUIDE.md](GUIDE.md)
+ - Read about our features at [FEATURES.md](FEATURES.md)
  - Bend is developed by [HigherOrderCO](https://higherorderco.com/) - join our [Discord](https://discord.higherorderco.com)!

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1,8 +1,8 @@
-> this is a WIP based on [Builtins.bend](https://github.com/HigherOrderCO/Bend/blob/main/src/fun/builtins.bend).
+> this is a WIP based on [Builtins.bend](../src/fun/builtins.bend).
 
 # Built-in Types and Functions
 
-**Bend** built-in types and functions, this document serves as a reference guide. Read more at [FEATURES.md](https://github.com/HigherOrderCO/Bend/blob/main/FEATURES.md).
+**Bend** built-in types and functions, this document serves as a reference guide. Read more at [FEATURES.md](../FEATURES.md).
 
 ## String
 
@@ -104,7 +104,7 @@ List/flatten([[1], [2, 3], [4]])
 
 ```python
 #{
-  Appends two lists together. 
+  Appends two lists together.
 #}
 def List/concat(xs: (List T)) (ys: (List T)) : (List T)
 ```
@@ -130,7 +130,7 @@ List/filter(xs: List(T), pred: T -> Bool) -> List(T)
 #{
   Splits a list into two lists at the first occurrence of a value.
 #}
-def List/split_once(xs: List(T), cond: T -> u24) -> (Result((List(T), List(T)), List(T))): 
+def List/split_once(xs: List(T), cond: T -> u24) -> (Result((List(T), List(T)), List(T))):
 ```
 Example:
 ```python
@@ -193,7 +193,7 @@ Technically your trees don't need to end with leaves, but if you don't, your pro
 ```python
 type Maybe(T):
   Some{ value }
-  None 
+  None
 ```
 **`Maybe`** is a structure that may or not contain a value. It is meant to be used as a return type for functions that can fail. This way you don't need to resort to unreachable() in order to handle errors.
 
@@ -208,7 +208,7 @@ maybe = Maybe/Some(Nat/Succ(Nat/Zero))
 ```python
 #{
 Returns the value inside the `Maybe` if it is `Some`, and returns `unreachable()` if it is `None`.
-#}  
+#}
 def Maybe/unwrap(m: Maybe(T)) -> T
 ```
 ## Map
@@ -216,7 +216,7 @@ def Maybe/unwrap(m: Maybe(T)) -> T
 ```python
 type Map(T):
   Node { value: Maybe(T), ~left: Map(T), ~right: Map(T) }
-  Leaf  
+  Leaf
 ```
 
 **`Map`** represents a tree with values stored in the branches.
@@ -257,7 +257,7 @@ Here, `map` must be the name of the `Map` variable, and the keys inside `[]` can
 ```python
 #{
   Initializes an empty map.
-#} 
+#}
 def Map/empty() -> Map(T)
 ```
 
@@ -268,8 +268,8 @@ def Map/empty() -> Map(T)
 ```rust
 #{
   Retrieves a `value` from the `map` based on the `key` and returns a tuple with the value and the `map` unchanged.
-  
-  The logic for checking whether a value is or not contained in a `map` is not done in the `get` function, so if we try to get a key that is not in the map, the program will return `unreachable`. 
+
+  The logic for checking whether a value is or not contained in a `map` is not done in the `get` function, so if we try to get a key that is not in the map, the program will return `unreachable`.
 #}
 def Map/get (map: Map(T), key: u24) -> (T, Map(T))
 ```
@@ -562,7 +562,7 @@ def IO/FS/write_file(path: String, bytes: List(u24)) -> IO(Result(None, u24))
 #{
   Moves the current position of the file with the given `file` descriptor to the given `offset`, an I24 or U24 number, in bytes.
 #}
-def IO/FS/seek(file: u24, offset: i24, mode: i24) -> IO(Result(None, u24)) 
+def IO/FS/seek(file: u24, offset: i24, mode: i24) -> IO(Result(None, u24))
 ```
 
 `mode` can be one of the following:
@@ -814,7 +814,7 @@ def Math/tan -> (f24 -> f24)
 #{
   Computes the cotangent of the given angle in radians.
 #}
-Math/cot (a: f24) : f24 
+Math/cot (a: f24) : f24
 ```
 
 ### Math/sec
@@ -824,7 +824,7 @@ Math/cot (a: f24) : f24
 #{
   Computes the secant of the given angle in radians.
 #}
-Math/sec (a: f24) : f24 
+Math/sec (a: f24) : f24
 ```
 
 ### Math/csc
@@ -834,7 +834,7 @@ Math/sec (a: f24) : f24
 #{
   Computes the cosecant of the given angle in radians.
 #}
-Math/csc (a: f24) : f24 
+Math/csc (a: f24) : f24
 ```
 
 ### Math/atan
@@ -845,7 +845,7 @@ Math/csc (a: f24) : f24
 #{
   Computes the arctangent of the given angle.
 #}
-Math/atan (a: f24) : f24 
+Math/atan (a: f24) : f24
 ```
 
 ### Math/asin
@@ -855,7 +855,7 @@ Math/atan (a: f24) : f24
 #{
   Computes the arcsine of the given angle.
 #}
-Math/asin (a: f24) : f24 
+Math/asin (a: f24) : f24
 ```
 
 ### Math/acos
@@ -874,7 +874,7 @@ Math/acos (a: f24) : f24
 #{
   Converts degrees to radians.
 #}
-Math/radians (a: f24) : f24 
+Math/radians (a: f24) : f24
 ```
 
 ### Math/sqrt
@@ -884,7 +884,7 @@ Math/radians (a: f24) : f24
 #{
   Computes the square root of the given number.
 #}
-Math/sqrt (n: f24) : f24 
+Math/sqrt (n: f24) : f24
 ```
 
 ### Math/ceil

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -95,7 +95,7 @@ The `~` notation indicates a recursive field. To use `fold` statements with a ty
 The constructor names inherit the name of their types and become functions (`Tree/Node` and `Tree/Leaf` in this case).
 The exact function they become depends on the encoding.
 
-Read [defining data types](./defining-data-types.md) to know more.
+Read [defining data types](defining-data-types.md) to know more.
 
 ### Object
 
@@ -567,7 +567,7 @@ A Tuple is surrounded by `(` `)` and should contain 2 or more elements. Elements
 
 A superposition of values is defined using `{` `}` with at least 2 expressions inside. Elements can be optionally separated by `,`.
 
-Read [sups and dups](./dups-and-sups.md) to know more.
+Read [sups and dups](dups-and-sups.md) to know more.
 
 ### Numbers and Infix Operations
 
@@ -783,7 +783,7 @@ Unscoped variables can't be defined in a rule pattern.
 
 The rule body is a term, there are no statements in the Fun variant of Bend.
 
-Read [pattern matching](./pattern-matching.md) to learn about what exactly the rules for pattern matching equations are.
+Read [pattern matching](pattern-matching.md) to learn about what exactly the rules for pattern matching equations are.
 
 ### Type
 
@@ -881,7 +881,7 @@ A tuple is surrounded by `(` `)`, with the difference that it's elements are sep
 
 A superposition of values is defined using `{` `}` with at least 2 terms inside.
 
-Read [sups and dups](./dups-and-sups.md) to know more.
+Read [sups and dups](dups-and-sups.md) to know more.
 
 ### Let-bindings
 
@@ -962,7 +962,7 @@ A pattern match expression, it can hold a name binding if the matching term is n
 
 It is possible to use a _wildcard_, a named variable or `*` as default cases.
 
-It is desugared according to the chosen encoding. Read [pattern matching](./pattern-matching.md) to know more.
+It is desugared according to the chosen encoding. Read [pattern matching](pattern-matching.md) to know more.
 
 Using `;` is optional.
 

--- a/docs/type-checking.md
+++ b/docs/type-checking.md
@@ -121,8 +121,8 @@ hvm native_id -> (a -> a):
 
 Currently, the following are not supported by the type checker:
 
-- Superpositions (`{a, b}`, the tuple type with duplication semantics, see [Dups and sups](https://github.com/HigherOrderCO/Bend/blob/main/docs/dups-and-sups.md)).
-- Unscoped variables and variable binds (`$a`, `let $a = ...`, see [Scopeless lambdas](https://github.com/HigherOrderCO/Bend/blob/main/docs/using-scopeless-lambdas.md)).
+- Superpositions (`{a, b}`, the tuple type with duplication semantics, see [Dups and sups](dups-and-sups.md)).
+- Unscoped variables and variable binds (`$a`, `let $a = ...`, see [Scopeless lambdas](using-scopeless-lambdas.md)).
 - Expressions not typeable by a Hindley-Milner type system (e.g. self application `λx: x(x)`).
 
 Additionally, the builtin types `Number` and `Integer` can't be used directly in type annotations. They are used internally by the type checker to handle numeric expressions.


### PR DESCRIPTION
- allow links to point to local files, where possible
- remove "./" for consistency across docs

There are other links that I've left untouched, such as those in `tests/`