### PR TITLE
Add --threads N to run-c/run-cu (sets HVM_THREADS on the spawned hvm)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,9 +222,12 @@ pub fn readback_hvm_net(
 fn run_hvm(book: &::hvm::ast::Book, cmd: &str, run_opts: &RunOpts) -> Result<String, String> {
   let out_path = ".out.hvm";
   std::fs::write(out_path, hvm_book_show_pretty(book)).map_err(|x| x.to_string())?;
-  let mut process = std::process::Command::new(run_opts.hvm_path.clone())
-    .arg(cmd)
-    .arg(out_path)
+  let mut command = std::process::Command::new(run_opts.hvm_path.clone());
+  command.arg(cmd).arg(out_path);
+  if let Some(threads) = run_opts.threads {
+    command.env("HVM_THREADS", threads.to_string());
+  }
+  let mut process = command
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::inherit())
     .spawn()
@@ -314,11 +317,14 @@ pub struct RunOpts {
   pub linear_readback: bool,
   pub pretty: bool,
   pub hvm_path: String,
+  /// Worker thread count for the parallel backends (run-c/run-cu), exported as
+  /// `HVM_THREADS` on the spawned `hvm` process. `None` keeps HVM's compiled TPC.
+  pub threads: Option<usize>,
 }
 
 impl Default for RunOpts {
   fn default() -> Self {
-    RunOpts { linear_readback: false, pretty: false, hvm_path: "hvm".to_string() }
+    RunOpts { linear_readback: false, pretty: false, hvm_path: "hvm".to_string(), threads: None }
   }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,12 @@ struct CliRunOpts {
 
   #[arg(short = 's', long = "stats", help = "Shows runtime stats and rewrite counts")]
   print_stats: bool,
+
+  #[arg(
+    long = "threads",
+    help = "Worker thread count: sets HVM_THREADS on the spawned hvm (read by the C runtime; other runtimes ignore it)"
+  )]
+  threads: Option<usize>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -327,7 +333,7 @@ fn execute_cli_mode(mut cli: Cli) -> Result<(), Diagnostics> {
     Mode::RunC(RunArgs { pretty, run_opts, comp_opts, warn_opts, path, arguments })
     | Mode::RunCu(RunArgs { pretty, run_opts, comp_opts, warn_opts, path, arguments })
     | Mode::RunRs(RunArgs { pretty, run_opts, comp_opts, warn_opts, path, arguments }) => {
-      let CliRunOpts { linear, print_stats } = run_opts;
+      let CliRunOpts { linear, print_stats, threads } = run_opts;
 
       let diagnostics_cfg =
         set_warning_cfg_from_cli(DiagnosticsConfig::new(Severity::Allow, arg_verbose), warn_opts);
@@ -336,7 +342,7 @@ fn execute_cli_mode(mut cli: Cli) -> Result<(), Diagnostics> {
 
       compile_opts.check_for_strict();
 
-      let run_opts = RunOpts { linear_readback: linear, pretty, hvm_path: hvm_bin };
+      let run_opts = RunOpts { linear_readback: linear, pretty, hvm_path: hvm_bin, threads };
 
       let book = load_book(&path, diagnostics_cfg)?;
       if let Some((term, stats, diags)) =


### PR DESCRIPTION
## What

A `--threads N` flag on the run subcommands that sets `HVM_THREADS=N` on the spawned `hvm` process. Companion to HigherOrderCO/HVM2#441, which makes the HVM C runtime read that variable at startup and clamp to the compiled `TPC`.

```sh
bend run prog.bend --threads 4 -s
```

## Why

HVM2's parallel C runtime fixes its worker count at compile time, so today there is no way to measure parallel scaling (speedup vs N threads) through Bend — tools can only compare whole backends (run-rs vs run-c vs run-cu), which conflates runtime quality with parallelism. A runtime thread count also lets users on shared machines / CI cap cores, and lets benchmarking tools pin a count for reproducibility.

`bend run-c file` invokes `hvm run-c <file>` with no thread argument, so there is nothing to thread a value through today.

## Patch

- `CliRunOpts` gains `--threads: Option<usize>`; it flows through `RunOpts` (new public `threads` field, `None` by default) into `run_hvm`, which sets `HVM_THREADS` on the child when present.
- `run-rs` is unaffected (the Rust interpreter ignores the variable).

## Backward compatibility

- No flag → no env var → byte-for-byte identical behavior.
- Old `hvm` binaries ignore the unknown env var, so a new Bend works against an old HVM (no scaling, but no breakage). With the HVM2 patch, `-s` additionally shows a `THREADS: N` readback so tools can confirm the count took effect.

## Testing

- Full test suite passes (`threads: None` default means existing `RunOpts { .. }` literals and golden tests are untouched).
- End-to-end against an `HVM_THREADS`-aware hvm: `bend run-c parallel_sum.bend --threads {1,4,16} -s` → identical Result/ITRS at every count, `THREADS: N` readback, 37 → 98 MIPS from 1 → 4 threads on a 16-core machine. Measured efficiency curve on depth-16 `parallel_sum.bend`: 1.00x/1.55x/2.43x/3.27x at 1/2/4/8 threads (ITRS identical at every count), requested 32 clamped to 16.
